### PR TITLE
Add tasks create

### DIFF
--- a/backend/db/migrations/2024-12-14-add-creator-id-to-tasks.sql
+++ b/backend/db/migrations/2024-12-14-add-creator-id-to-tasks.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tasks
+ADD COLUMN creator_id INT NOT NULL,
+ADD CONSTRAINT fk_task_creator
+FOREIGN KEY (creator_id) REFERENCES users(id);

--- a/backend/integration-tests/task.test.ts
+++ b/backend/integration-tests/task.test.ts
@@ -1,0 +1,25 @@
+import { expect, test, describe } from "vitest";
+import request from "supertest";
+
+import { createProject, registerUser, logMessage } from "./utils";
+
+const api = request("http://localhost:3000");
+
+describe("tasks tests", () => {
+  test("can perform various task operations", async () => {
+    const token = await registerUser(api);
+    const project = await createProject(api, token, "books");
+
+    logMessage("creating a new task");
+    const response = await api
+      .post("/tasks")
+      .set("Authorization", `Bearer ${token}`)
+      .set("Content-Type", "application/json")
+      .send({ project_id: project.id, name: "First task" })
+      .expect(201);
+
+    expect(response.body.name).toBe("First task");
+    expect(response.body.project_id).toBe(project.id);
+    expect(response.body.section_id).toBe(null);
+  });
+});

--- a/backend/integration-tests/utils.ts
+++ b/backend/integration-tests/utils.ts
@@ -1,5 +1,7 @@
 import request from "supertest";
 
+import type { Project } from "../src/types/entities/project";
+
 const username = createRandomName();
 const password = createRandomName();
 
@@ -16,6 +18,21 @@ export async function registerUser(
     .expect(201);
 
   return response.body.token as string;
+}
+
+export async function createProject(
+  api: ReturnType<typeof request>,
+  token: string,
+  projectName: string
+): Promise<Project> {
+  const response = await api
+    .post("/projects")
+    .set("Authorization", `Bearer ${token}`)
+    .set("Content-Type", "application/json")
+    .send({ name: projectName })
+    .expect(201);
+
+  return response.body as Project;
 }
 
 // create 16 random characters, should be good enough for unique names

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -15,3 +15,27 @@ const dbConfig: mysql.PoolOptions = {
 
 // Create a connection pool
 export const pool = mysql.createPool(dbConfig);
+
+export function prepareInsertQuery(
+  tableName: string,
+  values: Record<string, any>
+) {
+  const { names, params } = Object.entries(values).reduce<{
+    names: string[];
+    params: string[];
+  }>(
+    (acc, [key, value]) => {
+      acc.names.push(key);
+      acc.params.push(value);
+      return acc;
+    },
+    { names: [], params: [] }
+  );
+
+  const namesClause = names.join(", ");
+  const valuesClause = names.map(() => "?").join(", ");
+
+  const query = `INSERT INTO ${tableName} (${namesClause}) VALUES (${valuesClause})`;
+
+  return { query, params };
+}

--- a/backend/src/repositories/project.ts
+++ b/backend/src/repositories/project.ts
@@ -1,4 +1,4 @@
-import { pool } from "../db";
+import { pool, prepareInsertQuery } from "../db";
 
 import type { RowDataPacket, ResultSetHeader } from "mysql2/promise";
 import type { Project, ProjectUpdates } from "../types/entities/project";
@@ -12,11 +12,13 @@ export async function createProjectInDB({
   description?: string;
   userId: number;
 }) {
-  const [results] = await pool.execute<ResultSetHeader>(
-    "INSERT INTO projects (name, description, creator_id, is_archived) VALUES (?, ?, ?, ?)",
-    [name, description, userId, false]
-  );
-
+  const { query, params } = prepareInsertQuery("projects", {
+    name,
+    description,
+    creator_id: userId,
+    is_archived: false,
+  });
+  const [results] = await pool.execute<ResultSetHeader>(query, params);
   const [projects] = await pool.execute<RowDataPacket[]>(
     "SELECT id, name, description, is_archived, created_at, creator_id FROM projects WHERE id=?",
     [results.insertId]

--- a/backend/src/repositories/task.ts
+++ b/backend/src/repositories/task.ts
@@ -1,0 +1,35 @@
+import { pool, prepareInsertQuery } from "../db";
+
+import type { RowDataPacket, ResultSetHeader } from "mysql2/promise";
+import type { Task } from "../types/entities/task";
+
+export async function createTaskInDB({
+  project_id,
+  section_id = null,
+  name,
+  description = "",
+  userId,
+}: {
+  project_id: number;
+  section_id?: number | null;
+  name: string;
+  description?: string;
+  userId: number;
+}) {
+  const { query, params } = prepareInsertQuery("tasks", {
+    project_id,
+    section_id,
+    name,
+    description,
+    is_completed: false,
+    is_archived: false,
+    creator_id: userId,
+  });
+  const [results] = await pool.execute<ResultSetHeader>(query, params);
+  const [tasks] = await pool.execute<RowDataPacket[]>(
+    "SELECT * FROM tasks WHERE id=?",
+    [results.insertId]
+  );
+
+  return tasks[0] as Task;
+}

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -1,4 +1,4 @@
-import { type FastifyInstance, type RouteGenericInterface } from "fastify";
+import { type FastifyInstance } from "fastify";
 import { Type, Static } from "@sinclair/typebox";
 
 import { getUserIdFromRequest } from "../middleware/auth";

--- a/backend/src/routes/task.ts
+++ b/backend/src/routes/task.ts
@@ -1,0 +1,55 @@
+import { type FastifyInstance } from "fastify";
+
+import { createTaskInDB } from "../repositories/task";
+import { getProject } from "../repositories/project";
+import { getUserIdFromRequest } from "../middleware/auth";
+import { BadRequestError } from "../errors/errors";
+import {
+  type CreateTaskQuery,
+  CreateTaskQuerySchema,
+} from "../types/queries/task";
+import {
+  type CreateTaskResponse,
+  CreateTaskResponseSchema,
+} from "../types/responses/task";
+
+export function addTaskRoutes(fastify: FastifyInstance) {
+  addTaskCreateRoute(fastify);
+}
+
+function addTaskCreateRoute(fastify: FastifyInstance) {
+  fastify.post<{
+    Body: CreateTaskQuery;
+    Reply: { 201: CreateTaskResponse };
+  }>(
+    "/tasks",
+    {
+      schema: {
+        body: CreateTaskQuerySchema,
+        response: {
+          201: CreateTaskResponseSchema,
+        },
+      },
+    },
+    async function handler(request, reply) {
+      const userId = getUserIdFromRequest(request);
+      const project = await getProject(request.body.project_id);
+
+      if (!project || project.creator_id !== userId) {
+        throw new BadRequestError(
+          "Project id either does not exist or you don't have access to it"
+        );
+      }
+
+      const task = await createTaskInDB({
+        project_id: request.body.project_id,
+        section_id: request.body.section_id,
+        name: request.body.name,
+        description: request.body.description,
+        userId,
+      });
+
+      reply.code(201).send(task);
+    }
+  );
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ import Fastify, { type FastifyInstance } from "fastify";
 import { checkAuthentication } from "./middleware/auth";
 import { addUserRoutes } from "./routes/user";
 import { addProjectRoutes } from "./routes/project";
+import { addTaskRoutes } from "./routes/task";
 import { addErrorHandlers } from "./errors/server-errors";
 
 export async function startServer() {
@@ -23,6 +24,7 @@ export async function startServer() {
     // Add the middleware to all routes in this context
     scopedFastify.addHook("preHandler", checkAuthentication);
     addProjectRoutes(scopedFastify);
+    addTaskRoutes(scopedFastify);
   });
 
   try {

--- a/backend/src/types/entities/task.ts
+++ b/backend/src/types/entities/task.ts
@@ -1,0 +1,15 @@
+import { Type, Static } from "@sinclair/typebox";
+
+export const TaskSchema = Type.Object({
+  id: Type.Number(),
+  project_id: Type.Number(),
+  section_id: Type.Union([Type.Number(), Type.Null()]),
+  name: Type.String(),
+  description: Type.Optional(Type.String()),
+  is_completed: Type.Boolean(),
+  is_archived: Type.Boolean(),
+  created_at: Type.String(),
+  creator_id: Type.Number(),
+});
+
+export type Task = Static<typeof TaskSchema>;

--- a/backend/src/types/queries/project.ts
+++ b/backend/src/types/queries/project.ts
@@ -1,5 +1,5 @@
 import { Type, Static } from "@sinclair/typebox";
-import { ProjectUpdatesSchema, Project } from "../entities/project";
+import { ProjectUpdatesSchema } from "../entities/project";
 
 export const CreateProjectQuerySchema = Type.Object({
   name: Type.String({ minLength: 3, maxLength: 255 }),

--- a/backend/src/types/queries/task.ts
+++ b/backend/src/types/queries/task.ts
@@ -1,0 +1,10 @@
+import { Type, Static } from "@sinclair/typebox";
+
+export const CreateTaskQuerySchema = Type.Object({
+  project_id: Type.Number(),
+  section_id: Type.Optional(Type.Union([Type.Number(), Type.Null()])),
+  name: Type.String({ minLength: 1, maxLength: 255 }),
+  description: Type.Optional(Type.String({ maxLength: 255 })),
+});
+
+export type CreateTaskQuery = Static<typeof CreateTaskQuerySchema>;

--- a/backend/src/types/responses/task.ts
+++ b/backend/src/types/responses/task.ts
@@ -1,0 +1,4 @@
+import { TaskSchema, type Task } from "../entities/task";
+
+export const CreateTaskResponseSchema = TaskSchema;
+export type CreateTaskResponse = Task;


### PR DESCRIPTION
## Description

- add POST /tasks endpoint
- add migration to include `creator_id` to `tasks`
- abstract insert query into a helper to make sure statements have parameters in the correct order