### PR TITLE
add GET /task/:taskId route

### DIFF
--- a/backend/integration-tests/task.test.ts
+++ b/backend/integration-tests/task.test.ts
@@ -43,6 +43,21 @@ describe("tasks tests", () => {
     expect(allTasksResponse.body.length).toBe(2);
     expect(allTasksResponse.body).toContainEqual(task1);
     expect(allTasksResponse.body).toContainEqual(task2);
+
+    logMessage("getting individual tasks");
+    const firstTaskResponse = await api
+      .get(`/tasks/${task1.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+
+    expect(firstTaskResponse.body).toEqual(task1);
+
+    // const secondTaskResponse = await api
+    //   .get(`/tasks/${task2.id}`)
+    //   .set("Authorization", `Bearer ${token}`)
+    //   .expect(200);
+
+    // expect(secondTaskResponse.body).toEqual(task2);
   });
 });
 

--- a/backend/src/repositories/task.ts
+++ b/backend/src/repositories/task.ts
@@ -42,3 +42,16 @@ export async function getProjectTasks(projectId: number) {
 
   return tasks as Task[];
 }
+
+export async function getTaskById(taskId: number): Promise<null | Task> {
+  const [tasks] = await pool.execute<RowDataPacket[]>(
+    "SELECT * FROM tasks WHERE id=?",
+    [taskId]
+  );
+
+  if (!tasks[0]) {
+    return null;
+  }
+
+  return tasks[0] as Task;
+}

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -85,7 +85,6 @@ function addProjectsGetRoute(fastify: FastifyInstance) {
   );
 }
 
-// URL parameters schema
 const ParamsSchema = Type.Object({
   projectId: Type.Number(),
 });

--- a/backend/src/types/responses/task.ts
+++ b/backend/src/types/responses/task.ts
@@ -6,3 +6,6 @@ export type CreateTaskResponse = Task;
 
 export const GetTasksResponseSchema = Type.Array(TaskSchema);
 export type GetTasksResponse = Static<typeof GetTasksResponseSchema>;
+
+export const GetTaskResponseSchema = TaskSchema;
+export type GetTaskResponse = Static<typeof GetTaskResponseSchema>;


### PR DESCRIPTION
## Description

Add GET `/tasks/:taskId` route. Originally I wanted to implement transactions and modify projects DELETE and PUT, but I realized that I need to implement these methods on tasks first :)

So I'll work on everything tasks related, since they are independent (well, except for sections, I'll patch that in later).