### PR TITLE
safer task update handling

### DIFF
--- a/backend/src/errors/errors.ts
+++ b/backend/src/errors/errors.ts
@@ -27,3 +27,11 @@ export class BadRequestError extends AppError {
     super(400, message);
   }
 }
+
+export class ConflictError extends AppError {
+  constructor(
+    message: string = "Impossible to perform the operation due to conflicting state"
+  ) {
+    super(409, message);
+  }
+}

--- a/backend/src/repositories/task.ts
+++ b/backend/src/repositories/task.ts
@@ -73,7 +73,7 @@ export async function deleteProjectTasks(
   ]);
 }
 
-export async function updateTask(
+export async function updateTaskInDB(
   taskId: number,
   taskUpdates: TaskUpdates
 ): Promise<boolean> {

--- a/backend/src/services/task/index.ts
+++ b/backend/src/services/task/index.ts
@@ -1,0 +1,60 @@
+import { getTaskById, updateTaskInDB } from "../../repositories/task";
+import { getProject } from "../../repositories/project";
+import {
+  NotFoundError,
+  ForbiddenError,
+  ConflictError,
+} from "../../errors/errors";
+
+import type { Task, TaskUpdates } from "../../types/entities/task";
+import type { Project } from "../../types/entities/project";
+
+/**
+ * Get project by projectId, and check that:
+ *
+ * 1. It exists
+ * 2. User is the creator, so they have permissions to use it
+ *
+ * This function will throw errors in case it is not available.
+ */
+export async function getTaskAndVerify(taskId: number, userId: number) {
+  const task = await getTaskById(taskId);
+
+  if (!task) {
+    throw new NotFoundError();
+  }
+
+  if (task.creator_id !== userId) {
+    throw new ForbiddenError();
+  }
+
+  return task;
+}
+
+export async function updateTask({
+  task,
+  taskUpdates,
+  userId,
+}: {
+  task: Task;
+  taskUpdates: TaskUpdates;
+  userId: number;
+}) {
+  let project: Project | null = null;
+  if (taskUpdates.project_id && taskUpdates.project_id !== task.project_id) {
+    project = await getProject(taskUpdates.project_id);
+
+    if (!project || project.creator_id !== userId) {
+      throw new ConflictError("Cannot move task to the new project id");
+    }
+  }
+  if (taskUpdates.is_archived === false && task.is_archived === true) {
+    if (!project) {
+      project = await getProject(task.project_id);
+    }
+    if (project?.is_archived) {
+      throw new ConflictError("Cannot unarchive task when project is archived");
+    }
+  }
+  return updateTaskInDB(task.id, taskUpdates);
+}


### PR DESCRIPTION
## Description

Safer task update handling:

- When we unarchive a task, if the parent project is archived, don't allow that operation
- when we move a task to another project, check that it exists and belongs to the session user

## References

Closes https://github.com/Bloomca/todo-list-backend/issues/20