### PR TITLE
Add various /sections endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ All other endpoints require `Authorization: Bearer <TOKEN>` header.
 **Tasks**
 
 - POST `/tasks` -- create a new task. Accepts `project_id`, `name` and `description` fields
-- GET `/tasks?projectId=<PROJECT_ID`> -- get all project's tasks
+- GET `/tasks?projectId=<PROJECT_ID>` -- get all project's tasks
 - GET `/tasks/:taskID` -- get an individual task by ID
 - PUT `/tasks/:taskID` -- update a task
 - DELETE `/tasks/:taskID` -- delete a task
+
+**Sections**
+
+- POST `/section` -- create a new section. Expects `name` and `project_id` fields
+- GET `/sections?projectId=<PROJECT_ID>` -- get all project's sections
+- GET `/sections/:sectionId` -- get an individual section
+- DELETE `/sections/:sectionId` -- delete a section. It will delete all child tasks as well
+- PUT `/sections/:sectionId` -- update a section. Accepts `name`, `project_id` and `is_archived`. If `project_id` is changed, it will change all tasks as well; if it is archived, all tasks will be archived as well

--- a/backend/db/migrations/2024-12-15-add-creator-id-to-sections.sql
+++ b/backend/db/migrations/2024-12-15-add-creator-id-to-sections.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sections
+ADD COLUMN creator_id INT NOT NULL,
+ADD CONSTRAINT fk_section_creator
+FOREIGN KEY (creator_id) REFERENCES users(id);

--- a/backend/integration-tests/section.test.ts
+++ b/backend/integration-tests/section.test.ts
@@ -1,0 +1,136 @@
+import { expect, test, describe } from "vitest";
+import request from "supertest";
+
+import { createProject, registerUser, createTask, logMessage } from "./utils";
+
+import type { Section } from "../src/types/entities/section";
+
+const api = request("http://localhost:3000");
+
+describe("sections tests", () => {
+  test("can perform various section operations", async () => {
+    const token = await registerUser(api);
+    const project = await createProject(api, token, "books");
+
+    logMessage("creating new sections");
+    const section1 = await createSection({
+      token,
+      projectId: project.id,
+      sectionName: "First section",
+    });
+
+    expect(section1.name).toBe("First section");
+    expect(section1.project_id).toBe(project.id);
+
+    const section2 = await createSection({
+      token,
+      projectId: project.id,
+      sectionName: "Second section",
+    });
+
+    expect(section2.name).toBe("Second section");
+    expect(section2.project_id).toBe(project.id);
+
+    logMessage("getting all sections");
+    const allSectionsResponse = await api
+      .get("/sections")
+      .query({ project_id: project.id })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+
+    expect(allSectionsResponse.body.length).toBe(2);
+    expect(allSectionsResponse.body).toContainEqual(section1);
+    expect(allSectionsResponse.body).toContainEqual(section2);
+
+    logMessage("getting individual sections");
+    const firstSectionResponse = await api
+      .get(`/sections/${section1.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+
+    expect(firstSectionResponse.body).toEqual(section1);
+
+    const secondSectionResponse = await api
+      .get(`/sections/${section2.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+
+    expect(secondSectionResponse.body).toEqual(section2);
+
+    logMessage("can delete sections");
+    // create a task to make sure it is deleted as well
+    const firstTask = await createTask({
+      api,
+      token,
+      projectId: project.id,
+      sectionId: section2.id,
+      taskName: "first task",
+    });
+    await api
+      .delete(`/sections/${section2.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(204);
+
+    await api
+      .get(`/sections/${section2.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404);
+
+    await api
+      .get(`/tasks/${firstTask.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404);
+
+    logMessage("can update sections");
+    // create a task to make sure it is archived as well
+    const secondTask = await createTask({
+      api,
+      token,
+      projectId: project.id,
+      sectionId: section1.id,
+      taskName: "first task",
+    });
+    await api
+      .put(`/sections/${section1.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("Content-Type", "application/json")
+      .send({
+        name: "Updated section name",
+        is_archived: true,
+      })
+      .expect(204);
+
+    const updatedSectionResponse = await api
+      .get(`/sections/${section1.id}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(updatedSectionResponse.body.name).toBe("Updated section name");
+    expect(updatedSectionResponse.body.is_archived).toBe(true);
+
+    const updatedTaskResponse = await api
+      .get(`/tasks/${secondTask.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+
+    expect(updatedTaskResponse.body.is_archived).toBe(true);
+  });
+});
+
+async function createSection({
+  token,
+  projectId,
+  sectionName,
+}: {
+  token: string;
+  projectId: number;
+  sectionName: string;
+}) {
+  const response = await api
+    .post("/sections")
+    .set("Authorization", `Bearer ${token}`)
+    .set("Content-Type", "application/json")
+    .send({ project_id: projectId, name: sectionName })
+    .expect(201);
+
+  return response.body as Section;
+}

--- a/backend/integration-tests/utils.ts
+++ b/backend/integration-tests/utils.ts
@@ -41,17 +41,23 @@ export async function createTask({
   token,
   projectId,
   taskName,
+  sectionId = null,
 }: {
   api: ReturnType<typeof request>;
   token: string;
   projectId: number;
   taskName: string;
+  sectionId?: number | null;
 }) {
   const response = await api
     .post("/tasks")
     .set("Authorization", `Bearer ${token}`)
     .set("Content-Type", "application/json")
-    .send({ project_id: projectId, name: taskName })
+    .send({
+      project_id: projectId,
+      name: taskName,
+      section_id: sectionId,
+    })
     .expect(201);
 
   return response.body as Task;

--- a/backend/src/repositories/section.ts
+++ b/backend/src/repositories/section.ts
@@ -1,0 +1,88 @@
+import { pool, prepareInsertQuery } from "../db";
+
+import type {
+  RowDataPacket,
+  ResultSetHeader,
+  PoolConnection,
+} from "mysql2/promise";
+import type { Section, SectionUpdates } from "../types/entities/section";
+
+export async function createSectionInDB({
+  project_id,
+  name,
+  userId,
+}: {
+  project_id: number;
+  name: string;
+  userId: number;
+}) {
+  const { query, params } = prepareInsertQuery("sections", {
+    project_id,
+    name,
+    is_archived: false,
+    creator_id: userId,
+  });
+  const [results] = await pool.execute<ResultSetHeader>(query, params);
+  const [sections] = await pool.execute<RowDataPacket[]>(
+    "SELECT * FROM sections WHERE id=?",
+    [results.insertId]
+  );
+
+  return sections[0] as Section;
+}
+
+export async function getProjectSections(projectId: number) {
+  const [sections] = await pool.execute<RowDataPacket[]>(
+    "SELECT * FROM sections WHERE project_id=?",
+    [projectId]
+  );
+
+  return sections as Section[];
+}
+
+export async function getSectionById(
+  sectionId: number
+): Promise<null | Section> {
+  const [sections] = await pool.execute<RowDataPacket[]>(
+    "SELECT * FROM sections WHERE id=?",
+    [sectionId]
+  );
+
+  if (!sections[0]) {
+    return null;
+  }
+
+  return sections[0] as Section;
+}
+
+export async function deleteSection(
+  sectionId: number,
+  trx?: PoolConnection
+): Promise<void> {
+  await (trx ?? pool).execute("DELETE FROM sections WHERE id=?", [sectionId]);
+}
+
+export async function updateSectionInDB(
+  sectionId: number,
+  sectionUpdates: SectionUpdates,
+  trx?: PoolConnection
+): Promise<boolean> {
+  // Build the SET part of query and params array
+  const setClause = Object.keys(sectionUpdates)
+    .map((key) => `${key} = ?`)
+    .join(", ");
+  const params = [
+    ...Object.values(sectionUpdates).map((value) => value),
+    sectionId,
+  ];
+
+  const query = `
+    UPDATE sections 
+    SET ${setClause}
+    WHERE id = ?
+  `;
+
+  const [result] = await (trx ?? pool).execute<ResultSetHeader>(query, params);
+
+  return result.affectedRows !== 0;
+}

--- a/backend/src/repositories/task.ts
+++ b/backend/src/repositories/task.ts
@@ -29,6 +29,7 @@ export async function createTaskInDB({
     is_archived: false,
     creator_id: userId,
   });
+
   const [results] = await pool.execute<ResultSetHeader>(query, params);
   const [tasks] = await pool.execute<RowDataPacket[]>(
     "SELECT * FROM tasks WHERE id=?",
@@ -73,6 +74,26 @@ export async function deleteProjectTasks(
   ]);
 }
 
+export async function deleteSectionTasks(
+  sectionId: number,
+  trx?: PoolConnection
+): Promise<void> {
+  await (trx || pool).execute("DELETE FROM tasks WHERE section_id=?", [
+    sectionId,
+  ]);
+}
+
+export async function moveSectionTasks(
+  sectionId: number,
+  newProjectId: number,
+  trx: PoolConnection
+) {
+  await trx.execute("UPDATE tasks SET project_id=? WHERE section_id=?", [
+    newProjectId,
+    sectionId,
+  ]);
+}
+
 export async function updateTaskInDB(
   taskId: number,
   taskUpdates: TaskUpdates
@@ -96,10 +117,20 @@ export async function updateTaskInDB(
 
 export async function archiveProjectTasks(
   projectId: number,
-  trx?: PoolConnection
+  trx: PoolConnection
 ) {
-  await (trx ?? pool).execute(
-    "UPDATE tasks SET is_archived=? WHERE project_id=?",
-    [true, projectId]
-  );
+  await trx.execute("UPDATE tasks SET is_archived=? WHERE project_id=?", [
+    true,
+    projectId,
+  ]);
+}
+
+export async function archiveSectionTasks(
+  sectionId: number,
+  trx: PoolConnection
+) {
+  await trx.execute("UPDATE tasks SET is_archived=? WHERE section_id=?", [
+    true,
+    sectionId,
+  ]);
 }

--- a/backend/src/routes/project.ts
+++ b/backend/src/routes/project.ts
@@ -8,11 +8,7 @@ import {
   getProjectAndVerify,
   updateProjectWithData,
 } from "../services/project/index";
-import {
-  createProjectInDB,
-  getUserProjects,
-  updateProject,
-} from "../repositories/project";
+import { createProjectInDB, getUserProjects } from "../repositories/project";
 import {
   type CreateProjectQuery,
   CreateProjectQuerySchema,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,13 +1,51 @@
 import Fastify, { type FastifyInstance } from "fastify";
+import Ajv from "ajv";
 
 import { checkAuthentication } from "./middleware/auth";
 import { addUserRoutes } from "./routes/user";
 import { addProjectRoutes } from "./routes/project";
 import { addTaskRoutes } from "./routes/task";
+import { addSectionRoutes } from "./routes/section";
 import { addErrorHandlers } from "./errors/server-errors";
+
+const schemaCompilers = {
+  body: new Ajv({
+    removeAdditional: false,
+    // Disable coercion for request body so that `null` is not changed to `0`
+    coerceTypes: false,
+    allErrors: true,
+  }),
+  params: new Ajv({
+    removeAdditional: false,
+    coerceTypes: true,
+    allErrors: true,
+  }),
+  querystring: new Ajv({
+    removeAdditional: false,
+    coerceTypes: true,
+    allErrors: true,
+  }),
+  headers: new Ajv({
+    removeAdditional: false,
+    coerceTypes: true,
+    allErrors: true,
+  }),
+};
 
 export async function startServer() {
   const fastify = Fastify({ logger: true });
+
+  fastify.setValidatorCompiler((request) => {
+    if (!request.httpPart) {
+      throw new Error("Missing httpPart");
+    }
+    // @ts-expect-error we throw an error if compiler is not defined
+    const compiler = schemaCompilers[request.httpPart];
+    if (!compiler) {
+      throw new Error(`Missing compiler for ${request.httpPart}`);
+    }
+    return compiler.compile(request.schema);
+  });
 
   fastify.get("/health", async function handler(_request, reply) {
     reply.status(200).send({ status: "ok" });
@@ -25,6 +63,7 @@ export async function startServer() {
     scopedFastify.addHook("preHandler", checkAuthentication);
     addProjectRoutes(scopedFastify);
     addTaskRoutes(scopedFastify);
+    addSectionRoutes(scopedFastify);
   });
 
   try {

--- a/backend/src/services/section/index.ts
+++ b/backend/src/services/section/index.ts
@@ -1,0 +1,105 @@
+import {
+  getSectionById,
+  deleteSection,
+  updateSectionInDB,
+} from "../../repositories/section";
+import {
+  deleteSectionTasks,
+  moveSectionTasks,
+  archiveSectionTasks,
+} from "../../repositories/task";
+import { getProject } from "../../repositories/project";
+import {
+  NotFoundError,
+  ForbiddenError,
+  ConflictError,
+} from "../../errors/errors";
+import { executeTransaction } from "../../db";
+
+import type { Section, SectionUpdates } from "../../types/entities/section";
+import type { PoolConnection } from "mysql2/promise";
+
+/**
+ * Get section by sectionId, and check that:
+ *
+ * 1. It exists
+ * 2. User is the creator, so they have permissions to use it
+ *
+ * This function will throw errors in case it is not available.
+ */
+export async function getSectionAndVerify(
+  sectionId: number,
+  userId: number
+): Promise<Section> {
+  const section = await getSectionById(sectionId);
+
+  if (!section) {
+    throw new NotFoundError();
+  }
+
+  if (section.creator_id !== userId) {
+    throw new ForbiddenError();
+  }
+
+  return section;
+}
+
+export async function deleteSectionWithData(sectionId: number) {
+  await executeTransaction(async (trx) => {
+    await deleteSectionTasks(sectionId, trx);
+    await deleteSection(sectionId, trx);
+  });
+}
+
+export async function updateSection(
+  section: Section,
+  sectionUpdates: SectionUpdates,
+  userId: number
+) {
+  /**
+   * 1. Check if project_id changed
+   *   - if yes, check the new project existence and permissions
+   *   - change project_id for all section tasks
+   *   - update section
+   * 2. Check if it was archived
+   *   - if yes, archive all section tasks
+   *   - update section
+   * 3. Otherwise, just update the section
+   */
+
+  if (
+    sectionUpdates.project_id &&
+    sectionUpdates.project_id !== section.project_id
+  ) {
+    const newProject = await getProject(sectionUpdates.project_id);
+
+    if (
+      !newProject ||
+      newProject.creator_id !== userId ||
+      newProject.is_archived
+    ) {
+      throw new ConflictError("Cannot move section to the new project id");
+    }
+
+    return executeTransaction(async (trx) => {
+      await moveSectionTasks(section.id, newProject.id, trx);
+      return updateSectionWithArchiving(section, sectionUpdates, trx);
+    });
+  }
+
+  return executeTransaction(async (trx) =>
+    updateSectionWithArchiving(section, sectionUpdates, trx)
+  );
+}
+
+async function updateSectionWithArchiving(
+  section: Section,
+  sectionUpdates: SectionUpdates,
+  trx: PoolConnection
+) {
+  if (sectionUpdates.is_archived && !section.is_archived) {
+    await archiveSectionTasks(section.id, trx);
+  }
+
+  return updateSectionInDB(section.id, sectionUpdates, trx);
+}

--- a/backend/src/services/task/index.ts
+++ b/backend/src/services/task/index.ts
@@ -10,7 +10,7 @@ import type { Task, TaskUpdates } from "../../types/entities/task";
 import type { Project } from "../../types/entities/project";
 
 /**
- * Get project by projectId, and check that:
+ * Get task by taskId, and check that:
  *
  * 1. It exists
  * 2. User is the creator, so they have permissions to use it

--- a/backend/src/types/entities/section.ts
+++ b/backend/src/types/entities/section.ts
@@ -1,0 +1,20 @@
+import { Type, Static } from "@sinclair/typebox";
+
+export const SectionSchema = Type.Object({
+  id: Type.Number(),
+  project_id: Type.Number(),
+  name: Type.String(),
+  is_archived: Type.Boolean(),
+  created_at: Type.String(),
+  creator_id: Type.Number(),
+});
+
+export type Section = Static<typeof SectionSchema>;
+
+export const SectionUpdatesSchema = Type.Object({
+  project_id: Type.Optional(Type.Number()),
+  name: Type.Optional(Type.String()),
+  is_archived: Type.Optional(Type.Boolean()),
+});
+
+export type SectionUpdates = Static<typeof SectionUpdatesSchema>;

--- a/backend/src/types/queries/section.ts
+++ b/backend/src/types/queries/section.ts
@@ -1,0 +1,20 @@
+import { Type, Static } from "@sinclair/typebox";
+import { SectionUpdatesSchema } from "../entities/section";
+
+export const CreateSectionQuerySchema = Type.Object({
+  project_id: Type.Number(),
+  name: Type.String({ minLength: 1, maxLength: 255 }),
+});
+
+export type CreateSectionQuery = Static<typeof CreateSectionQuerySchema>;
+
+export const GetProjectSectionsQuerySchema = Type.Object({
+  project_id: Type.Number(),
+});
+
+export type GetProjectSectionsQuery = Static<
+  typeof GetProjectSectionsQuerySchema
+>;
+
+export const UpdateSectionQuerySchema = SectionUpdatesSchema;
+export type UpdateSectionQuery = Static<typeof UpdateSectionQuerySchema>;

--- a/backend/src/types/responses/section.ts
+++ b/backend/src/types/responses/section.ts
@@ -1,0 +1,13 @@
+import { Type, Static } from "@sinclair/typebox";
+import { SectionSchema, type Section } from "../entities/section";
+
+export const CreateSectionResponseSchema = SectionSchema;
+export type CreateSectionResponse = Section;
+
+export const GetProjectSectionsResponseSchema = Type.Array(SectionSchema);
+export type GetProjectSectionsResponse = Static<
+  typeof GetProjectSectionsResponseSchema
+>;
+
+export const GetSectionResponseSchema = SectionSchema;
+export type GetSectionResponse = Static<typeof GetSectionResponseSchema>;


### PR DESCRIPTION
## Description

Add several endpoints:

- POST `/section` -- create a new section. Expects `name` and `project_id`
- GET `/sections` -- get all sections
- GET `/sections/:sectionId` -- get individual section
- DELETE `/sections/:sectionId` -- delete a section. It will delete all child tasks as well
- PUT `/sections/:sectionId` -- update a section. If `project_id` is changed, it will change all tasks as well; if it is archived, all tasks will be archived as well