### PR TITLE
adjust production setup to use external MySQL

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,7 +19,8 @@ COPY package*.json ./
 RUN npm install --production
 
 COPY --from=builder /usr/src/app/dist ./dist
+COPY --from=builder /usr/src/app/db ./db
 
-EXPOSE 3000
+EXPOSE 6072
 
 CMD ["node", "dist/index.js"]

--- a/backend/db/01-init.sql
+++ b/backend/db/01-init.sql
@@ -1,6 +1,6 @@
-CREATE DATABASE IF NOT EXISTS myapp;
+CREATE DATABASE IF NOT EXISTS todo_list_backend;
 
-USE myapp;
+USE todo_list_backend;
 
 CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon --exec ts-node src/index.ts",
-    "buid": "tsc",
+    "build": "tsc",
     "test:integration": "vitest run"
   },
   "repository": {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -68,7 +68,7 @@ export async function startServer() {
 
   try {
     await fastify.listen({
-      port: 3000,
+      port: getPort(),
       /**
        * Because we run this app in the Docker, we need to enable all connections.
        * By default, Fastify only allows localhost/IPv6 connections.
@@ -80,4 +80,14 @@ export async function startServer() {
     fastify.log.error(err);
     process.exit(1);
   }
+}
+
+function getPort() {
+  const envPort = Number(process.env.APP_PORT);
+
+  if (isNaN(envPort)) {
+    return 3000;
+  }
+
+  return envPort;
 }

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -10,7 +10,7 @@ services:
       - DB_HOST=mysql
       - DB_USER=user
       - DB_PASSWORD=password
-      - DB_NAME=myapp
+      - DB_NAME=todo_list_backend
       - DB_PORT=3306
       - REDIS_HOST=redis
       - REDIS_PORT=6379

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -8,12 +8,22 @@ services:
     environment:
       - NODE_ENV=production
       - DB_HOST=mysql
-      - DB_USER=user
-      - DB_PASSWORD=password
-      - DB_NAME=myapp
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_NAME=todo_list_backend
       - DB_PORT=3306
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - APP_PORT=6072
     depends_on:
-      - mysql
       - redis
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+volumes:
+  redis_data:

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -8,7 +8,7 @@ services:
       - DB_HOST=mysql
       - DB_USER=user
       - DB_PASSWORD=password
-      - DB_NAME=myapp
+      - DB_NAME=todo_list_backend
       - DB_PORT=3306
       - REDIS_HOST=redis
       - REDIS_PORT=6379

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "3306:3306"
     environment:
-      - MYSQL_DATABASE=myapp
+      - MYSQL_DATABASE=todo_list_backend
       - MYSQL_USER=user
       - MYSQL_PASSWORD=password
       - MYSQL_ROOT_PASSWORD=rootpassword

--- a/start.sh
+++ b/start.sh
@@ -46,7 +46,7 @@ case "$command" in
 esac
 
 # production start (will compile TS to JS and only start with production dependencies):
-# docker compose -f compose.yml -f compose.prod.yml up -d
+# docker compose -f compose.prod.yml up --build -d
 
 # To connect to the database:
 # docker compose exec mysql mysql -u user -ppassword myapp


### PR DESCRIPTION
## Description

Adjust production setup to use external MySQL.

Production setup uses DB user/password from the `.env` file, and uses different app port (6072).
