### PR TITLE
change to archived_at field in projects and sections

### DIFF
--- a/backend/db/migrations/2024-12-30-change-to-archived-at-field.sql
+++ b/backend/db/migrations/2024-12-30-change-to-archived-at-field.sql
@@ -1,0 +1,28 @@
+-- projects part
+
+ALTER TABLE projects
+ADD COLUMN archived_at TIMESTAMP NULL;
+
+UPDATE projects
+SET archived_at = CURRENT_TIMESTAMP()
+WHERE is_archived = 1;
+
+ALTER TABLE projects
+DROP COLUMN is_archived;
+
+-- sections part
+
+ALTER TABLE sections
+ADD COLUMN archived_at TIMESTAMP NULL;
+
+UPDATE sections
+SET archived_at = CURRENT_TIMESTAMP()
+WHERE is_archived = 1;
+
+ALTER TABLE sections
+DROP COLUMN is_archived;
+
+-- tasks part; we don't want to keep their archiving status
+
+ALTER TABLE tasks
+DROP COLUMN is_archived;

--- a/backend/integration-tests/project.test.ts
+++ b/backend/integration-tests/project.test.ts
@@ -61,16 +61,6 @@ describe("project tests", () => {
       .expect(404);
 
     logMessage("can update projects");
-    /**
-     * We create a task first, so that it will be archived as well.
-     */
-    const secondTask = await createTask({
-      api,
-      token,
-      projectId: project2.id,
-      taskName: "task to be archived",
-    });
-    expect(secondTask.is_archived).toBe(false);
     await api
       .put(`/projects/${project2.id}`)
       .set("Authorization", `Bearer ${token}`)
@@ -91,15 +81,8 @@ describe("project tests", () => {
 
     expect(updatedProjectResponse.body.name).toBe("Updated project name");
     expect(updatedProjectResponse.body.description).toBe("New description");
-    expect(updatedProjectResponse.body.is_archived).toBe(true);
+    expect(typeof updatedProjectResponse.body.archived_at).toBe("string");
     expect(updatedProjectResponse.body.display_order).toBe(5);
-
-    const updatedTask = await api
-      .get(`/tasks/${secondTask.id}`)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(200);
-
-    expect(updatedTask.body.is_archived).toBe(true);
   });
 });
 

--- a/backend/integration-tests/section.test.ts
+++ b/backend/integration-tests/section.test.ts
@@ -86,14 +86,6 @@ describe("sections tests", () => {
       .expect(404);
 
     logMessage("can update sections");
-    // create a task to make sure it is archived as well
-    const secondTask = await createTask({
-      api,
-      token,
-      projectId: project.id,
-      sectionId: section1.id,
-      taskName: "first task",
-    });
     await api
       .put(`/sections/${section1.id}`)
       .set("Authorization", `Bearer ${token}`)
@@ -110,15 +102,8 @@ describe("sections tests", () => {
       .set("Authorization", `Bearer ${token}`);
 
     expect(updatedSectionResponse.body.name).toBe("Updated section name");
-    expect(updatedSectionResponse.body.is_archived).toBe(true);
+    expect(typeof updatedSectionResponse.body.archived_at).toBe("string");
     expect(updatedSectionResponse.body.display_order).toBe(5);
-
-    const updatedTaskResponse = await api
-      .get(`/tasks/${secondTask.id}`)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(200);
-
-    expect(updatedTaskResponse.body.is_archived).toBe(true);
   });
 });
 

--- a/backend/integration-tests/task.test.ts
+++ b/backend/integration-tests/task.test.ts
@@ -82,7 +82,6 @@ describe("tasks tests", () => {
       .send({
         name: "Updated task name",
         description: "New description",
-        is_archived: true,
         display_order: 4,
       })
       .expect(204);
@@ -93,7 +92,6 @@ describe("tasks tests", () => {
 
     expect(updatedTaskResponse.body.name).toBe("Updated task name");
     expect(updatedTaskResponse.body.description).toBe("New description");
-    expect(updatedTaskResponse.body.is_archived).toBe(true);
     expect(updatedTaskResponse.body.display_order).toBe(4);
   });
 });

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -16,9 +16,9 @@ export const dbConfig: mysql.PoolOptions = {
 // Create a connection pool
 export const pool = mysql.createPool(dbConfig);
 
-export function prepareInsertQuery(
+export function prepareInsertQuery<T extends Record<string, any>>(
   tableName: string,
-  values: Record<string, any>
+  values: T
 ) {
   const { names, params } = Object.entries(values).reduce<{
     names: string[];

--- a/backend/src/repositories/task.ts
+++ b/backend/src/repositories/task.ts
@@ -22,13 +22,12 @@ export async function createTaskInDB({
   userId: number;
   display_order?: number;
 }) {
-  const { query, params } = prepareInsertQuery("tasks", {
+  const { query, params } = prepareInsertQuery<Partial<Task>>("tasks", {
     project_id,
     section_id,
     name,
     description,
     is_completed: false,
-    is_archived: false,
     creator_id: userId,
     display_order: display_order ?? 1,
   });
@@ -116,24 +115,4 @@ export async function updateTaskInDB(
   const [result] = await pool.execute<ResultSetHeader>(query, params);
 
   return result.affectedRows !== 0;
-}
-
-export async function archiveProjectTasks(
-  projectId: number,
-  trx: PoolConnection
-) {
-  await trx.execute("UPDATE tasks SET is_archived=? WHERE project_id=?", [
-    true,
-    projectId,
-  ]);
-}
-
-export async function archiveSectionTasks(
-  sectionId: number,
-  trx: PoolConnection
-) {
-  await trx.execute("UPDATE tasks SET is_archived=? WHERE section_id=?", [
-    true,
-    sectionId,
-  ]);
 }

--- a/backend/src/routes/project/update.ts
+++ b/backend/src/routes/project/update.ts
@@ -5,7 +5,7 @@ import { getUserIdFromRequest } from "../../middleware/auth";
 import { NotFoundError, BadRequestError } from "../../errors/errors";
 import {
   getProjectAndVerify,
-  updateProjectWithData,
+  updateProject,
 } from "../../services/project/index";
 import {
   type UpdateProjectQuery,
@@ -40,7 +40,7 @@ export function addProjectUpdateRoute(fastify: FastifyInstance) {
       if (isEmpty) {
         throw new BadRequestError("No updated project fields");
       }
-      const wasUpdated = await updateProjectWithData(project, request.body);
+      const wasUpdated = await updateProject(project, request.body);
 
       if (!wasUpdated) {
         // this should be handled earlier, so just to be safe

--- a/backend/src/routes/task/create.ts
+++ b/backend/src/routes/task/create.ts
@@ -38,7 +38,7 @@ export function addTaskCreateRoute(fastify: FastifyInstance) {
         );
       }
 
-      if (project.is_archived) {
+      if (project.archived_at !== null) {
         throw new ConflictError("Cannot create tasks in archived projects");
       }
 
@@ -51,7 +51,7 @@ export function addTaskCreateRoute(fastify: FastifyInstance) {
           );
         }
 
-        if (section.is_archived) {
+        if (section.archived_at !== null) {
           throw new ConflictError("Cannot create tasks in archived sections");
         }
       }

--- a/backend/src/services/project/index.ts
+++ b/backend/src/services/project/index.ts
@@ -1,14 +1,8 @@
 import { getProjectFromDB } from "../../repositories/project";
 import { NotFoundError, ForbiddenError } from "../../errors/errors";
-import {
-  deleteProjectTasks,
-  archiveProjectTasks,
-} from "../../repositories/task";
-import {
-  deleteProjectSectionsFromDB,
-  archiveProjectSectionsInDB,
-} from "../../repositories/section";
-import { deleteProject, updateProject } from "../../repositories/project";
+import { deleteProjectTasks } from "../../repositories/task";
+import { deleteProjectSectionsFromDB } from "../../repositories/section";
+import { deleteProject, updateProjectInDB } from "../../repositories/project";
 import { executeTransaction } from "../../db";
 
 import { Project, ProjectUpdates } from "../../types/entities/project";
@@ -26,24 +20,11 @@ export async function deleteProjectWithData(projectId: number) {
   });
 }
 
-/**
- * Update project and correctly archive all associated entities
- * if the project is being archived.
- */
-export async function updateProjectWithData(
+export async function updateProject(
   project: Project,
   projectUpdates: ProjectUpdates
 ): Promise<boolean> {
-  // when we are archiving a project, we need to archive its tasks
-  if (!project.is_archived && projectUpdates.is_archived === true) {
-    return executeTransaction(async function archiveProjectAndData(trx) {
-      await archiveProjectTasks(project.id, trx);
-      await archiveProjectSectionsInDB(project.id, trx);
-      return updateProject(project.id, projectUpdates, trx);
-    });
-  } else {
-    return updateProject(project.id, projectUpdates);
-  }
+  return updateProjectInDB(project.id, projectUpdates);
 }
 
 /**

--- a/backend/src/services/section/create.ts
+++ b/backend/src/services/section/create.ts
@@ -21,7 +21,7 @@ export async function createSection({
     );
   }
 
-  if (project.is_archived) {
+  if (project.archived_at !== null) {
     throw new ConflictError("Cannot create section in archived projects");
   }
 

--- a/backend/src/services/task/index.ts
+++ b/backend/src/services/task/index.ts
@@ -61,32 +61,16 @@ export async function updateTask({
       throw new ConflictError("Cannot move task to the new section id");
     }
   }
-  if (taskUpdates.is_archived === false && task.is_archived === true) {
-    if (!project) {
-      project = await getProjectFromDB(task.project_id);
-    }
-    if (project?.is_archived) {
-      throw new ConflictError("Cannot unarchive task when project is archived");
-    }
-
-    if (!section && taskUpdates.section_id !== null && task.section_id) {
-      section = await getSectionById(task.section_id);
-    }
-
-    if (section?.is_archived) {
-      throw new ConflictError("Cannot unarchive task when section is archived");
-    }
-  }
 
   // otherwise we'd thrown an error "NotFound", so `project` should be available
   if (hasNewProjectId && project) {
-    if (project.is_archived) {
+    if (project.archived_at !== null) {
       throw new ConflictError("Cannot move task to the archived project");
     }
   }
 
   if (hasNewSectionId && taskUpdates.section_id !== null && section) {
-    if (section.is_archived) {
+    if (section.archived_at !== null) {
       throw new ConflictError("Cannot move task to the archived section");
     }
   }

--- a/backend/src/types/entities/project.ts
+++ b/backend/src/types/entities/project.ts
@@ -4,7 +4,7 @@ export const ProjectSchema = Type.Object({
   id: Type.Number(),
   name: Type.String(),
   description: Type.Optional(Type.String()),
-  is_archived: Type.Boolean(),
+  archived_at: Type.Union([Type.String(), Type.Null()]),
   display_order: Type.Integer(),
   created_at: Type.String(),
   creator_id: Type.Number(),

--- a/backend/src/types/entities/section.ts
+++ b/backend/src/types/entities/section.ts
@@ -4,7 +4,7 @@ export const SectionSchema = Type.Object({
   id: Type.Number(),
   project_id: Type.Number(),
   name: Type.String(),
-  is_archived: Type.Boolean(),
+  archived_at: Type.Union([Type.String(), Type.Null()]),
   display_order: Type.Number(),
   created_at: Type.String(),
   creator_id: Type.Number(),

--- a/backend/src/types/entities/task.ts
+++ b/backend/src/types/entities/task.ts
@@ -7,7 +7,6 @@ export const TaskSchema = Type.Object({
   name: Type.String(),
   description: Type.Optional(Type.String()),
   is_completed: Type.Boolean(),
-  is_archived: Type.Boolean(),
   display_order: Type.Number(),
   created_at: Type.String(),
   creator_id: Type.Number(),
@@ -22,7 +21,6 @@ export const TaskUpdatesSchema = Type.Object({
   description: Type.Optional(Type.Optional(Type.String())),
   display_order: Type.Optional(Type.Integer({ minimum: 1 })),
   is_completed: Type.Optional(Type.Boolean()),
-  is_archived: Type.Optional(Type.Boolean()),
 });
 
 export type TaskUpdates = Static<typeof TaskUpdatesSchema>;


### PR DESCRIPTION
## Description

Change to `archived_at` field, remove it from tasks and also do not cascade changes. This has several benefits:

- simpler logic
- unarchiving means that previous state of sections will be preserved

Also tasks don't really need to be archived, at least not until they can be nested.

## Reference

Closes https://github.com/Bloomca/todo-list-backend/issues/29, although I changed the strategy as described above.