### PR TITLE
change to completed_at field in tasks

### DIFF
--- a/backend/db/migrations/2024-12-31-1-change-to-completed-at-field.sql
+++ b/backend/db/migrations/2024-12-31-1-change-to-completed-at-field.sql
@@ -1,0 +1,9 @@
+ALTER TABLE tasks
+ADD COLUMN completed_at TIMESTAMP NULL;
+
+UPDATE tasks
+SET completed_at = CURRENT_TIMESTAMP()
+WHERE is_completed = 1;
+
+ALTER TABLE tasks
+DROP COLUMN is_completed;

--- a/backend/integration-tests/task.test.ts
+++ b/backend/integration-tests/task.test.ts
@@ -93,6 +93,22 @@ describe("tasks tests", () => {
     expect(updatedTaskResponse.body.name).toBe("Updated task name");
     expect(updatedTaskResponse.body.description).toBe("New description");
     expect(updatedTaskResponse.body.display_order).toBe(4);
+
+    logMessage("can complete tasks");
+    await api
+      .put(`/tasks/${task1.id}`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("Content-Type", "application/json")
+      .send({
+        is_completed: true,
+      })
+      .expect(204);
+
+    const updatedTaskResponse2 = await api
+      .get(`/tasks/${task1.id}`)
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(typeof updatedTaskResponse2.body.completed_at).toBe("string");
   });
 });
 

--- a/backend/src/types/entities/task.ts
+++ b/backend/src/types/entities/task.ts
@@ -6,7 +6,7 @@ export const TaskSchema = Type.Object({
   section_id: Type.Union([Type.Number(), Type.Null()]),
   name: Type.String(),
   description: Type.Optional(Type.String()),
-  is_completed: Type.Boolean(),
+  completed_at: Type.Union([Type.String(), Type.Null()]),
   display_order: Type.Number(),
   created_at: Type.String(),
   creator_id: Type.Number(),


### PR DESCRIPTION
## Description

Similar to https://github.com/Bloomca/todo-list-backend/pull/31, change to `completed_at`, which is a timestamp at the moment of completion. The overhead should be small, but this approach will allow us to show date of completion and sort by it as well.